### PR TITLE
Increase testing backchannel waiting time to 50ms

### DIFF
--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1104,8 +1104,8 @@ class MatterBaseTest(base_test.BaseTestClass):
                 logger.info(f"Sending out-of-band command: {command} to file: {app_pipe_name}")
                 app_pipe.write(json.dumps(command_dict) + "\n")
 
-            # TODO(#31239): remove the need for sleep
-            sleep(0.001)
+            # TODO(#31239): remove the need for sleep, teill then let's wait 50ms
+            sleep(0.05)
         else:
             logging.info(f"Using DUT IP address: {dut_ip}")
 

--- a/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
+++ b/src/python_testing/matter_testing_infrastructure/chip/testing/matter_testing.py
@@ -1104,7 +1104,7 @@ class MatterBaseTest(base_test.BaseTestClass):
                 logger.info(f"Sending out-of-band command: {command} to file: {app_pipe_name}")
                 app_pipe.write(json.dumps(command_dict) + "\n")
 
-            # TODO(#31239): remove the need for sleep, teill then let's wait 50ms
+            # TODO(#31239): remove the need for sleep, till then let's wait 50ms
             sleep(0.05)
         else:
             logging.info(f"Using DUT IP address: {dut_ip}")


### PR DESCRIPTION
#### Testing

The merge of https://github.com/project-chip/connectedhomeip/commit/0b7c1c597ff538428bb1aab7cf6a8f84fe718fde now leads to centralized backchannel communication via the file socket which is great, but the very short waiting time of 1ms is a bit short for all cases to reduce flaky tests - especially also when matter.js is used as DuT, so increasing that wait time to 50ms at least should give. more stability for the tests
